### PR TITLE
Add a blog post about macOS Memory Forensics with Volatility 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ extraction of digital artifacts from volatile memory (RAM) samples.
 ### Blogs
 - [📦 Volatility3 Windows Plugin : Prefetch](https://www.forensicxlab.com/posts/prefetch/)
 - [📦 Volatility3 Linux Plugin : Inodes](https://www.forensicxlab.com/posts/inodes/)
-- [Memory analysis using volatility3 (1) - Windows 10](https://cpuu.postype.com/post/9993241)
-- [Memory analysis using volatility3 (2) - Ubuntu Linux](https://cpuu.postype.com/post/11807930)
+- [Memory analysis using volatility3 (1) - Windows 11](https://cpuu.hashnode.dev/how-to-perform-memory-forensic-analysis-in-windows-11-using-volatility-3)
+- [Memory analysis using volatility3 (2) - Ubuntu Linux](https://cpuu.hashnode.dev/how-to-perform-memory-forensic-analysis-in-linux-using-volatility-3)
 - [Realizing Windows Memory Forensics with Volatility and Gimp](https://developpaper.com/ctf-realizing-windows-memory-forensics-with-volatility-and-gimp/)
 
 ### CheastSheet

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ extraction of digital artifacts from volatile memory (RAM) samples.
 - [📦 Volatility3 Linux Plugin : Inodes](https://www.forensicxlab.com/posts/inodes/)
 - [Memory analysis using volatility3 (1) - Windows 11](https://cpuu.hashnode.dev/how-to-perform-memory-forensic-analysis-in-windows-11-using-volatility-3)
 - [Memory analysis using volatility3 (2) - Ubuntu Linux](https://cpuu.hashnode.dev/how-to-perform-memory-forensic-analysis-in-linux-using-volatility-3)
+- [Memory analysis using volatility3 (3) - macOS](https://cpuu.hashnode.dev/how-to-perform-memory-forensic-analysis-in-macos-using-volatility-3)
 - [Realizing Windows Memory Forensics with Volatility and Gimp](https://developpaper.com/ctf-realizing-windows-memory-forensics-with-volatility-and-gimp/)
 
 ### CheastSheet


### PR DESCRIPTION
Introducing a blog post guide on macOS memory forensic analysis using Volatility 3, covering memory dump acquisition to ISF file generation. Highlights tool limitations and community-driven solutions for practitioners.